### PR TITLE
Remove sudo from makefile and add .out docs to make clean target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,8 +24,8 @@ install:
 	@find ./docs -type f -iname "*.5.gz" \
 		-exec install -Dm 644 {} -t $(DESTDIR)/$(MAN5_DIR) \;
 	@install -Dm 755 ./target/release/$(DAEMON_BINARY) -t $(DESTDIR)/$(TARGET_DIR)
-	@sudo chown root:root $(DESTDIR)/$(TARGET_DIR)/$(DAEMON_BINARY)
-	@sudo chmod u+s $(DESTDIR)/$(TARGET_DIR)/$(DAEMON_BINARY)
+	chown root:root $(DESTDIR)/$(TARGET_DIR)/$(DAEMON_BINARY)
+	chmod u+s $(DESTDIR)/$(TARGET_DIR)/$(DAEMON_BINARY)
 	@install -Dm 755 ./target/release/$(SERVER_BINARY) -t $(DESTDIR)/$(TARGET_DIR)
 	# Ideally, we would have a default config file instead of an empty one
 	@if [ ! -f $(DESTDIR)/etc/$(DAEMON_BINARY)/$(DAEMON_BINARY)rc ]; then \

--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,7 @@ test:
 clean:
 	@cargo clean
 	@$(RM) -f ./docs/*.gz
+	@$(RM) -f ./docs/*.out
 	@$(RM) -f $(DAEMON_BINARY)rc
 
 setup:


### PR DESCRIPTION
this PR removes an unnecessary usage of `sudo` from the install target, `make install` will fail without superuser(chown will fail) permissions and must be ran  `{sudo,doas} make install` making this usage redundant. This usage caused the program to fail on machines without `sudo`.

I also added `docs/*.out` to the make `clean` target, this is in line with `make clean` clearing docs/*.gz.